### PR TITLE
Reworked events & added unit tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
 			"beforeColon": false,
 			"afterColon": true
 		}],
+		"no-invalid-regexp": "error",
 		"no-multi-spaces": "error",
 		"no-trailing-spaces": "error",
 		"object-curly-spacing": "error",

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Supported events:
 
 Events can be used like this:
 ```js
-Bot.getClient().getEvents().on("<event-name>", (returnValue) => {
+Bot.getClient().onEvent("<event-name>", (returnValue) => {
 	//Code that shall be executed when the event was triggered
 });
 ```
@@ -54,10 +54,10 @@ There is also an example of a simple bot implementation to get started withk:
 const {DiscordBot} = require("dynobot-framework");
 const Bot = new DiscordBot("<discord-token>");
 
-Bot.getClient().getEvents().on("ready", () => {
+Bot.getClient().onEvent("ready", () => {
 	console.log("Bot started");
 
-	Bot.getClient().getEvents().on("message", (msg) => {
+	Bot.getClient().onEvent("message", (msg) => {
 		if (msg.isMentioned(Bot.getClient().getUser())) {
 			msg.getChannel().send("OK");
 		}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.com/Blackhawk-TA/dynoBot-Framework.svg?branch=master)](https://travis-ci.com/Blackhawk-TA/dynoBot-Framework)
 [![npm](https://img.shields.io/npm/v/dynobot-framework.svg?color=brightgreen)](https://www.npmjs.com/package/dynobot-framework)
 [![github](https://img.shields.io/github/release/Blackhawk-TA/dynoBot-Framework.svg?color=brightgreen)](https://github.com/Blackhawk-TA/dynoBot-Framework/releases)
+[![github](https://img.shields.io/github/package-json/v/Blackhawk-TA/dynoBot-Framework/master.svg?color=blue)](https://github.com/Blackhawk-TA/dynoBot-Framework/tree/master)
 [![github](https://img.shields.io/github/package-json/v/Blackhawk-TA/dynoBot-Framework/development.svg?color=blue)](https://github.com/Blackhawk-TA/dynoBot-Framework/tree/development)
 
 ### Overview

--- a/README.md
+++ b/README.md
@@ -26,18 +26,11 @@ http://dynodoc.tapadventures.com/
 `npm install dynobot-framework`
 
 Now you can use the framework by adding following line:
-
 ```js
 const {DiscordBot} = require("dynobot-framework");
 ```
 
 ### Events
-Events have to be registered before they can be used. This can be done by the following line:
-
-```js
-Bot.getClient().registerEvent("<event-name>");
-```
-
 Supported events:
 - `error` - returns Error object
 - `serverMemberAdd` - returns User object
@@ -45,8 +38,7 @@ Supported events:
 - `message` - returns Message object
 - `ready` - no return value
 
-Once a event is registered, it can be used like this:
-
+Events can be used like this:
 ```js
 Bot.getClient().getEvents().on("<event-name>", (returnValue) => {
 	//Code that shall be executed when the event was triggered
@@ -61,9 +53,6 @@ There is also an example of a simple bot implementation to get started withk:
 ```js
 const {DiscordBot} = require("dynobot-framework");
 const Bot = new DiscordBot("<discord-token>");
-
-Bot.getClient().registerEvent("ready");
-Bot.getClient().registerEvent("message");
 
 Bot.getClient().getEvents().on("ready", () => {
 	console.log("Bot started");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dynobot-framework",
-	"version": "1.0.6",
+	"version": "1.1.0",
 	"description": "A TypeScript framework which works as an API wrapper for chat bots such as discord or slack.",
 	"main": "./build/src/DiscordBot.js",
 	"scripts": {

--- a/src/wrappers/discord/DiscordClient.ts
+++ b/src/wrappers/discord/DiscordClient.ts
@@ -43,6 +43,19 @@ export class DiscordClient implements IClient {
 		this._events = new EventEmitter();
 		this._user = new DiscordUser(client.user);
 		this._client = client;
+
+		for (let name in this._apiEvents) { //register events
+			let Event: EventHandler = new EventHandler(name, this._apiEvents);
+			let wrappedName: string = Event.getApiEventName();
+			this._client.on(wrappedName, (object) => {
+				let WrappedObject = Event.getWrappedObject(object);
+				if (WrappedObject) {
+					this._events.emit(name, WrappedObject);
+				} else {
+					this._events.emit(name);
+				}
+			});
+		}
 	}
 
 	getEvents(): EventEmitter {
@@ -61,18 +74,5 @@ export class DiscordClient implements IClient {
 		});
 
 		return wrappedServers;
-	}
-
-	registerEvent(name: string): void {
-		let Event: EventHandler = new EventHandler(name, this._apiEvents);
-		let wrappedName: string = Event.getApiEventName();
-		this._client.on(wrappedName, (object) => {
-			let WrappedObject = Event.getWrappedObject(object);
-			if (WrappedObject) {
-				this._events.emit(name, WrappedObject);
-			} else {
-				this._events.emit(name);
-			}
-		});
 	}
 }

--- a/src/wrappers/discord/DiscordClient.ts
+++ b/src/wrappers/discord/DiscordClient.ts
@@ -6,6 +6,7 @@ import {IServer} from "../interfaces/IServer";
 import {DiscordServer} from "./DiscordServer";
 import {DiscordMessage} from "./DiscordMessage";
 import {EventHandler} from "../../utils/EventHandler";
+import {ErrorHandler} from "../../utils/ErrorHandler";
 
 export class DiscordClient implements IClient {
 	private readonly _events: EventEmitter;
@@ -58,8 +59,12 @@ export class DiscordClient implements IClient {
 		}
 	}
 
-	getEvents(): EventEmitter {
-		return this._events;
+	onEvent(name: string, listener: (...args: any[]) => void): void {
+		if (this._apiEvents.hasOwnProperty(name)) {
+			this._events.on(name, listener);
+		} else {
+			ErrorHandler.throwErrorMessage(`The event '${name}' is not supported.`);
+		}
 	}
 
 	getUser(): IUser {

--- a/src/wrappers/discord/DiscordClient.ts
+++ b/src/wrappers/discord/DiscordClient.ts
@@ -47,8 +47,8 @@ export class DiscordClient implements IClient {
 
 		for (let name in this._apiEvents) { //register events
 			let Event: EventHandler = new EventHandler(name, this._apiEvents);
-			let wrappedName: string = Event.getApiEventName();
-			this._client.on(wrappedName, (object) => {
+			let apiEventName: string = Event.getApiEventName();
+			this._client.on(apiEventName, (object) => {
 				let WrappedObject = Event.getWrappedObject(object);
 				if (WrappedObject) {
 					this._events.emit(name, WrappedObject);

--- a/src/wrappers/interfaces/IClient.ts
+++ b/src/wrappers/interfaces/IClient.ts
@@ -1,13 +1,13 @@
-import {EventEmitter} from "events";
 import {IServer} from "./IServer";
 import {IUser} from "./IUser";
 
 export interface IClient {
 	/**
-	 * Get the event emitter of the client to allow reacting on events
-	 * @return The event emitter
+	 * Executes a given listener function when the referred event was triggered
+	 * @param name - The name of the event
+	 * @param listener - The event listener, a function which shall be executed once the event was triggered
 	 */
-	getEvents(): EventEmitter;
+	onEvent(name: string, listener: (...args: any[]) => void): void;
 
 	/**
 	 * Get the wrapped user object from the client.

--- a/src/wrappers/interfaces/IClient.ts
+++ b/src/wrappers/interfaces/IClient.ts
@@ -20,10 +20,4 @@ export interface IClient {
 	 * @return The servers of the client
 	 */
 	getServers(): IServer[]
-
-	/**
-	 * Registers a new event which can be accessed later.
-	 * @param name - The name of the event
-	 */
-	registerEvent(name: string): void;
 }

--- a/tests/discord/DiscordBotTest.ts
+++ b/tests/discord/DiscordBotTest.ts
@@ -7,26 +7,28 @@ const assert = require("assert");
 require("dotenv").config();
 const token = process.env.DISCORD_TOKEN;
 
-describe("The bot initialisation", function() {
-	it("Has a user which is not yet defined", function() {
-		//Act
-		let Bot: IBot = new DiscordBot(token);
+describe("The class DiscordBot", function() {
+	describe("The bot initialisation", function() {
+		it("Has a user which is not yet defined", function() {
+			//Act
+			let Bot: IBot = new DiscordBot(token);
 
-		//Assert
-		try {
-			assert.ifError(Bot.getClient().getUser().getId());
-		} catch (e) {
-			assert.strictEqual(e.toString(), "TypeError: Cannot read property 'id' of null");
-		}
+			//Assert
+			try {
+				assert.ifError(Bot.getClient().getUser().getId());
+			} catch (e) {
+				assert.strictEqual(e.toString(), "TypeError: Cannot read property 'id' of null");
+			}
+		});
 	});
-});
 
-describe("The getter", function() {
-	it("Has a getter which returns the wrapped client object", function() {
-		//Act
-		let Bot: IBot = new DiscordBot(token);
+	describe("The getter", function() {
+		it("Has a getter which returns the wrapped client object", function() {
+			//Act
+			let Bot: IBot = new DiscordBot(token);
 
-		//Assert
-		assert.strictEqual(Bot.getClient() instanceof DiscordClient, true, "The wrapped client object was returned.");
+			//Assert
+			assert.strictEqual(Bot.getClient() instanceof DiscordClient, true, "The wrapped client object was returned.");
+		});
 	});
 });

--- a/tests/discord/DiscordClientTest.ts
+++ b/tests/discord/DiscordClientTest.ts
@@ -1,43 +1,56 @@
 import {DiscordClient} from "../../src/wrappers/discord/DiscordClient";
 import {EventEmitter} from "events";
 import {DiscordUser} from "../../src/wrappers/discord/DiscordUser";
+import {DiscordServer} from "../../src/wrappers/discord/DiscordServer";
+import {IServer} from "../../src/wrappers/interfaces/IServer";
 
 const assert = require("assert");
 const sinon = require("sinon");
 
-describe("The class DiscordClient", function () {
-	beforeEach(function () {
-		let _client = {
-			on: function() {},
+describe("The class DiscordClient", function() {
+	beforeEach(function() {
+		let client: object = {
+			on: function() {
+			},
 			_user: {}
 		};
-		this.clientOnCallStub = sinon.stub(_client, "on"); //TODO fix stub
-		this.Client = new DiscordClient(_client);
+		this.clientOnCallStub = sinon.stub(client, "on");
+		this.Client = new DiscordClient(client);
 	});
 
-	afterEach(function () {
+	afterEach(function() {
 		this.clientOnCallStub.restore();
 		this.Client = null;
 	});
 
 	describe("The constructor event registration", function() {
-		//TODO implement
+		it("Calls the 'on' method for each event", function() {
+			//Assert
+			assert.strictEqual(this.clientOnCallStub.callCount, 5, "The correct amount of events were registered.");
+			assert.strictEqual(this.clientOnCallStub.getCall(0).args[0], "error", "The 'on' method was called for the 'error' event.");
+			assert.strictEqual(this.clientOnCallStub.getCall(1).args[0], "guildMemberAdd", "The 'on' method was called for the 'guildMemberAdd' event.");
+			assert.strictEqual(this.clientOnCallStub.getCall(2).args[0], "guildMemberRemove", "The 'on' method was called for the 'guildMemberRemove' event.");
+			assert.strictEqual(this.clientOnCallStub.getCall(3).args[0], "message", "The 'on' method was called for the 'message' event.");
+			assert.strictEqual(this.clientOnCallStub.getCall(4).args[0], "ready", "The 'on' method was called for the 'ready' event.");
+		});
 	});
 
-	describe("The method onEvent", function () {
-		it("Throws an error if the event is not supported", function () {
+	describe("The method onEvent", function() {
+		it("Throws an error if the event is not supported", function() {
 			try {
 				//Act
-				this.Client.onEvent("test", () => {});
+				this.Client.onEvent("test", () => {
+				});
 			} catch (e) {
 				//Assert
-				assert.throws(e.toString, "The event 'test' is not supported.", "The correct error was thrown.");
+				assert.strictEqual(e.toString(), "Error: The event 'test' is not supported.", "The correct error was thrown.");
 			}
 		});
 
-		it("Use the original event emitter", function () {
+		it("Use the original event emitter", function() {
 			//Arrange
-			let listener = function() {};
+			let listener = function() {
+			};
 			let onEventEmitterStub = sinon.stub(EventEmitter.prototype, "on");
 
 			//Act
@@ -52,8 +65,8 @@ describe("The class DiscordClient", function () {
 		});
 	});
 
-	describe("The method getUser", function () {
-		it("Returns the wrapped user object", function () {
+	describe("The method getUser", function() {
+		it("Returns the wrapped user object", function() {
 			//Act
 			let User = this.Client.getUser();
 
@@ -63,6 +76,64 @@ describe("The class DiscordClient", function () {
 	});
 
 	describe("The method getServers", function() {
-		//TODO implement
+		it("Returns an empty array", function() {
+			//Arrange
+			let client: object = {
+				on: function() {},
+				guilds: {
+					array: function() {
+						return [];
+					}
+				}
+			};
+			let Client: DiscordClient = new DiscordClient(client);
+
+			//Act
+			let Servers: IServer[] = Client.getServers();
+
+			//Assert
+			assert.deepStrictEqual(Servers, [], "An empty array was returned.");
+		});
+
+		it("Returns an array containing one server", function() {
+			//Arrange
+			let client: object = {
+				on: function() {},
+				guilds: {
+					array: function() {
+						return [{}];
+					}
+				}
+			};
+			let Client: DiscordClient = new DiscordClient(client);
+
+			//Act
+			let Servers: IServer[] = Client.getServers();
+
+			//Assert
+			assert.strictEqual(Servers.length, 1, "The length of the returned array is correct.");
+			assert.strictEqual(Servers[0] instanceof DiscordServer, true, "The server object was wrapped correctly.");
+		});
+
+		it("Returns an array containing two servers", function() {
+			//Arrange
+			let client: object = {
+				on: function() {},
+				guilds: {
+					array: function() {
+						return [{}, {}];
+					}
+				}
+			};
+			let Client: DiscordClient = new DiscordClient(client);
+
+			//Act
+			let Servers: IServer[] = Client.getServers();
+
+			//Assert
+			assert.strictEqual(Servers.length, 2, "The length of the returned array is correct.");
+			assert.strictEqual(Servers[0] instanceof DiscordServer, true, "The server object was wrapped correctly.");
+			assert.strictEqual(Servers[1] instanceof DiscordServer, true, "The server object was wrapped correctly.");
+		});
 	});
 });

--- a/tests/discord/DiscordClientTest.ts
+++ b/tests/discord/DiscordClientTest.ts
@@ -1,0 +1,68 @@
+import {DiscordClient} from "../../src/wrappers/discord/DiscordClient";
+import {EventEmitter} from "events";
+import {DiscordUser} from "../../src/wrappers/discord/DiscordUser";
+
+const assert = require("assert");
+const sinon = require("sinon");
+
+describe("The class DiscordClient", function () {
+	beforeEach(function () {
+		let _client = {
+			on: function() {},
+			_user: {}
+		};
+		this.clientOnCallStub = sinon.stub(_client, "on"); //TODO fix stub
+		this.Client = new DiscordClient(_client);
+	});
+
+	afterEach(function () {
+		this.clientOnCallStub.restore();
+		this.Client = null;
+	});
+
+	describe("The constructor event registration", function() {
+		//TODO implement
+	});
+
+	describe("The method onEvent", function () {
+		it("Throws an error if the event is not supported", function () {
+			try {
+				//Act
+				this.Client.onEvent("test", () => {});
+			} catch (e) {
+				//Assert
+				assert.throws(e.toString, "The event 'test' is not supported.", "The correct error was thrown.");
+			}
+		});
+
+		it("Use the original event emitter", function () {
+			//Arrange
+			let listener = function() {};
+			let onEventEmitterStub = sinon.stub(EventEmitter.prototype, "on");
+
+			//Act
+			this.Client.onEvent("ready", listener);
+
+			//Assert
+			assert.strictEqual(onEventEmitterStub.getCall(0).args[0], "ready", "The correct event name was handed over.");
+			assert.strictEqual(onEventEmitterStub.getCall(0).args[1], listener, "The correct listener was handed over.");
+
+			//Cleanup
+			onEventEmitterStub.restore();
+		});
+	});
+
+	describe("The method getUser", function () {
+		it("Returns the wrapped user object", function () {
+			//Act
+			let User = this.Client.getUser();
+
+			//Assert
+			assert.strictEqual(User instanceof DiscordUser, true, "The user object was wrapped correctly.");
+		});
+	});
+
+	describe("The method getServers", function() {
+		//TODO implement
+	});
+});

--- a/tests/discord/DiscordRoleTest.ts
+++ b/tests/discord/DiscordRoleTest.ts
@@ -1,45 +1,47 @@
 import {DiscordRole} from "../../src/wrappers/discord/DiscordRole";
 const assert = require("assert");
 
-beforeEach(function() {
-	this._role = {
-		id: 123,
-		name: "roleName",
-		color: 321,
-		permissions: 12345
-	};
-	this.Role = new DiscordRole(this._role);
-});
-
-afterEach(function() {
-	this.Role = null;
-	this._role = null;
-});
-
-describe("The method getId", function() {
-	it("Returns the role id as number", function() {
-		//Assert
-		assert.strictEqual(this.Role.getId(), this._role.id, "The correct role id was returned.");
+describe("The class DiscordRole", function() {
+	beforeEach(function() {
+		this._role = {
+			id: 123,
+			name: "roleName",
+			color: 321,
+			permissions: 12345
+		};
+		this.Role = new DiscordRole(this._role);
 	});
-});
 
-describe("The method getName", function() {
-	it("Returns the role name as string", function() {
-		//Assert
-		assert.strictEqual(this.Role.getName(), this._role.name, "The correct role name was returned.");
+	afterEach(function() {
+		this.Role = null;
+		this._role = null;
 	});
-});
 
-describe("The method getColor", function() {
-	it("Returns the role color as number", function() {
-		//Assert
-		assert.strictEqual(this.Role.getColor(), this._role.color, "The correct role color was returned.");
+	describe("The method getId", function() {
+		it("Returns the role id as number", function() {
+			//Assert
+			assert.strictEqual(this.Role.getId(), this._role.id, "The correct role id was returned.");
+		});
 	});
-});
 
-describe("The method getPermissions", function() {
-	it("Returns the role permissions as number", function() {
-		//Assert
-		assert.deepStrictEqual(this.Role.getPermissions(), this._role.permissions, "The correct role permissions were returned.");
+	describe("The method getName", function() {
+		it("Returns the role name as string", function() {
+			//Assert
+			assert.strictEqual(this.Role.getName(), this._role.name, "The correct role name was returned.");
+		});
+	});
+
+	describe("The method getColor", function() {
+		it("Returns the role color as number", function() {
+			//Assert
+			assert.strictEqual(this.Role.getColor(), this._role.color, "The correct role color was returned.");
+		});
+	});
+
+	describe("The method getPermissions", function() {
+		it("Returns the role permissions as number", function() {
+			//Assert
+			assert.deepStrictEqual(this.Role.getPermissions(), this._role.permissions, "The correct role permissions were returned.");
+		});
 	});
 });

--- a/tests/discord/DiscordUserTest.ts
+++ b/tests/discord/DiscordUserTest.ts
@@ -1,0 +1,114 @@
+import {DiscordUser} from "../../src/wrappers/discord/DiscordUser";
+import {DiscordChannel} from "../../src/wrappers/discord/DiscordChannel";
+
+const assert = require("assert");
+
+describe("The class DiscordUser", function() {
+	beforeEach(function() {
+		let _user: object = {
+			id: 123,
+			username: "name"
+		};
+		this.User = new DiscordUser(_user);
+	});
+
+	afterEach(function() {
+		this.User = null;
+	});
+
+	describe("The method getId", function() {
+		it("Returns the user id", function() {
+			//Act
+			let userId: number = this.User.getId();
+
+			//Assert
+			assert.strictEqual(userId, 123, "The correct user id was returned.");
+		});
+	});
+
+	describe("The method getName", function() {
+		it("Returns the username", function() {
+			//Act
+			let username: number = this.User.getName();
+
+			//Assert
+			assert.strictEqual(username, "name", "The correct username was returned.");
+		});
+	});
+
+	describe("The method createDM", function() {
+		it("Resolves the promise and returns the channel", function() {
+			//Arrange
+			let _user: object = {
+				createDM: function() {
+					return new Promise(resolve => {
+						resolve({});
+					});
+				}
+			};
+			let User: DiscordUser = new DiscordUser(_user);
+
+			//Act
+			return User.createDM().then(resolve => {
+				//Assert
+				assert.strictEqual(resolve instanceof DiscordChannel, true, "The promise returned a wrapped DiscordChannel.");
+			});
+		});
+
+		it("Rejects the promise and returns the reason", function() {
+			//Arrange
+			let _user: object = {
+				createDM: function() {
+					return new Promise(reject => {
+						reject("some reason");
+					});
+				}
+			};
+			let User: DiscordUser = new DiscordUser(_user);
+
+			//Act
+			return User.createDM().catch(reject => {
+				//Assert
+				assert.strictEqual(reject, "some reason", "The promise returned the reason for its rejection.");
+			});
+		});
+	});
+
+	describe("The method deleteDM", function() {
+		it("Resolves the promise and returns the channel", function() {
+			//Arrange
+			let _user: object = {
+				deleteDM: function() {
+					return new Promise(resolve => {
+						resolve({});
+					});
+				}
+			};
+			let User: DiscordUser = new DiscordUser(_user);
+
+			//Act
+			return User.deleteDM().then(resolve => {
+				//Assert
+				assert.strictEqual(resolve instanceof DiscordChannel, true, "The promise returned a wrapped DiscordChannel.");
+			});
+		});
+
+		it("Rejects the promise and returns the reason", function() {
+			//Arrange
+			let _user: object = {
+				deleteDM: function() {
+					return new Promise(reject => {
+						reject("some reason");
+					});
+				}
+			};
+			let User: DiscordUser = new DiscordUser(_user);
+
+			//Act
+			return User.deleteDM().catch(reject => {
+				//Assert
+				assert.strictEqual(reject, "some reason", "The promise returned the reason for its rejection.");
+			});
+		});
+	});
+});

--- a/tests/utils/ErrorHandlerTest.ts
+++ b/tests/utils/ErrorHandlerTest.ts
@@ -1,0 +1,68 @@
+import {ErrorHandler} from "../../src/utils/ErrorHandler";
+
+const assert = require("assert");
+const sinon = require("sinon");
+
+describe("The class ErrorHandler", function() {
+	describe("The method log", function() {
+		beforeEach(function() {
+			this.consoleStub = sinon.stub(console, "error");
+		});
+
+		afterEach(function() {
+			this.consoleStub.restore();
+		});
+
+		it("Logs the given error message as error to the console", function() {
+			//Arrange
+			let errorMessage: string = "my error message";
+
+			//Act
+			ErrorHandler.log(errorMessage);
+
+			//Assert
+			assert.strictEqual(this.consoleStub.getCall(0).args[0], errorMessage, "The correct error message was logged.");
+		});
+
+		it("Logs the given error object to the console", function() {
+			//Arrange
+			let error: Error = new Error("my error message");
+
+			//Act
+			ErrorHandler.log(error);
+
+			//Assert
+			assert.strictEqual(this.consoleStub.getCall(0).args[0], error, "The correct error object was logged.");
+		});
+	});
+
+	describe("The method throwErrorMessage", function() {
+		it("Converts the error message to an error object and throws it", function() {
+			//Assert
+			let errorMessage: string = "my error message";
+
+			try {
+				//Act
+				ErrorHandler.throwErrorMessage(errorMessage);
+			} catch (e) {
+				//Assert
+				assert.strictEqual(e.toString(), "Error: my error message", "The correct error was thrown.");
+			}
+		});
+	});
+
+	describe("The method throwError", function() {
+		it("Throws the error object", function() {
+			//Assert
+			let error: Error = new Error("my error message");
+
+			try {
+				//Act
+				ErrorHandler.throwError(error);
+			} catch (e) {
+				//Assert
+				assert.strictEqual(e, error, "The correct error was thrown.");
+			}
+		});
+	});
+});

--- a/tests/utils/EventHandlerTest.ts
+++ b/tests/utils/EventHandlerTest.ts
@@ -3,79 +3,81 @@ import {EventHandler} from "../../src/utils/EventHandler";
 
 const assert = require("assert");
 
-beforeEach(function() {
-	this._apiEvents = {
-		error: {
-			name: "error",
-			returnClass: Error,
-			isWrapped: false
-		},
-		serverMemberAdd: {
-			name: "guildMemberAdd"
-		},
-		message: {
-			name: "message",
-			returnClass: DiscordMessage,
-			isWrapped: true
-		},
-		ready: {
-			name: "ready",
-			returnClass: null,
-			isWrapped: false,
-		}
-	};
-});
-
-afterEach(function() {
-	this._apiEvents = null;
-});
-
-describe("The method getApiEventName", function() {
-	it("Returns the original unwrapped api event name", function() {
-		//Arrange
-		let Event: EventHandler = new EventHandler("serverMemberAdd", this._apiEvents);
-
-		//Act
-		let apiEventName: string = Event.getApiEventName();
-
-		//Assert
-		assert.strictEqual(apiEventName, "guildMemberAdd", "The correct name of the original api event was returned.");
-	});
-});
-
-describe("The method getWrappedObject", function() {
-	it("Returns the wrapped object of the event", function() {
-		//Arrange
-		let Event: EventHandler = new EventHandler("message", this._apiEvents);
-		let apiObject: object = {};
-
-		//Act
-		let WrappedObject: any = Event.getWrappedObject(apiObject);
-
-		//Assert
-		assert.strictEqual(WrappedObject instanceof DiscordMessage, true, "The api object was wrapped correctly.");
+describe("The class EventHandler", function() {
+	beforeEach(function() {
+		this._apiEvents = {
+			error: {
+				name: "error",
+				returnClass: Error,
+				isWrapped: false
+			},
+			serverMemberAdd: {
+				name: "guildMemberAdd"
+			},
+			message: {
+				name: "message",
+				returnClass: DiscordMessage,
+				isWrapped: true
+			},
+			ready: {
+				name: "ready",
+				returnClass: null,
+				isWrapped: false,
+			}
+		};
 	});
 
-	it("Returns the api object because it should not be wrapped", function() {
-		//Arrange
-		let Event: EventHandler = new EventHandler("error", this._apiEvents);
-		let apiObject: Error = new Error("test error");
-
-		//Act
-		let WrappedObject: any = Event.getWrappedObject(apiObject);
-
-		//Assert
-		assert.strictEqual(WrappedObject, apiObject, "The api object was returned because it should not be wrapped.");
+	afterEach(function() {
+		this._apiEvents = null;
 	});
 
-	it("Returns null if the event has no return value and shall not be wrapped", function() {
-		//Arrange
-		let Event: EventHandler = new EventHandler("ready", this._apiEvents);
+	describe("The method getApiEventName", function() {
+		it("Returns the original unwrapped api event name", function() {
+			//Arrange
+			let Event: EventHandler = new EventHandler("serverMemberAdd", this._apiEvents);
 
-		//Act
-		let WrappedObject: any = Event.getWrappedObject(undefined);
+			//Act
+			let apiEventName: string = Event.getApiEventName();
 
-		//Assert
-		assert.strictEqual(WrappedObject, null, "Null was returned because the wrapped event has no return value.");
+			//Assert
+			assert.strictEqual(apiEventName, "guildMemberAdd", "The correct name of the original api event was returned.");
+		});
+	});
+
+	describe("The method getWrappedObject", function() {
+		it("Returns the wrapped object of the event", function() {
+			//Arrange
+			let Event: EventHandler = new EventHandler("message", this._apiEvents);
+			let apiObject: object = {};
+
+			//Act
+			let WrappedObject: any = Event.getWrappedObject(apiObject);
+
+			//Assert
+			assert.strictEqual(WrappedObject instanceof DiscordMessage, true, "The api object was wrapped correctly.");
+		});
+
+		it("Returns the api object because it should not be wrapped", function() {
+			//Arrange
+			let Event: EventHandler = new EventHandler("error", this._apiEvents);
+			let apiObject: Error = new Error("test error");
+
+			//Act
+			let WrappedObject: any = Event.getWrappedObject(apiObject);
+
+			//Assert
+			assert.strictEqual(WrappedObject, apiObject, "The api object was returned because it should not be wrapped.");
+		});
+
+		it("Returns null if the event has no return value and shall not be wrapped", function() {
+			//Arrange
+			let Event: EventHandler = new EventHandler("ready", this._apiEvents);
+
+			//Act
+			let WrappedObject: any = Event.getWrappedObject(undefined);
+
+			//Assert
+			assert.strictEqual(WrappedObject, null, "Null was returned because the wrapped event has no return value.");
+		});
 	});
 });


### PR DESCRIPTION
Events are now registered implicitly which leads to a removal of the IClient.registerEvent method.
Also event listeners are now used in a different way. 
`Bot.getClient().getEvents().on("event", listener)` 
was replaced by:
`Bot.getClient().onEvent("event", listener)`

Tests added for following classes:
- DiscordUser
- DiscordClient
- ErrorHandler